### PR TITLE
Fix missing dependency QtQML.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ option(ENABLE_TEST "Enable test" Off)
 add_definitions(-DTRANSLATION_DOMAIN=\"org.fcitx.fcitx5.kcm\")
 add_definitions(-DFCITX_GETTEXT_DOMAIN=\"fcitx5-configtool\")
 
-find_package(Qt5 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS Core Gui Widgets X11Extras Concurrent)
+find_package(Qt5 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS Core Gui Widgets X11Extras Concurrent Qml)
 
 if (ENABLE_CONFIG_QT)
     find_package(KF5ItemViews REQUIRED)

--- a/src/lib/configlib/CMakeLists.txt
+++ b/src/lib/configlib/CMakeLists.txt
@@ -16,5 +16,5 @@ set_target_properties(configlib PROPERTIES
     AUTOUIC_OPTIONS "-tr=fcitx::tr2fcitx;--include=fcitxqti18nhelper.h"
 )
 target_include_directories(configlib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(configlib Qt5::Core Qt5::Gui Fcitx5Qt5::DBusAddons Fcitx5::Core Fcitx5::Utils)
+target_link_libraries(configlib Qt5::Core Qt5::Gui Qt5::Qml Fcitx5Qt5::DBusAddons Fcitx5::Core Fcitx5::Utils)
 


### PR DESCRIPTION
`src/lib/configlib/layoutprovider.cpp` contains `#include <QtQml/qqml.h>` but CMakeLists.txt doesn't add link target to QtQML and cause a build failure on Guix. This patch attempt to fix this by adding QtQML to link target and `find_package` argument .