### PR TITLE
Change icon to preferences-desktop-keyboard

### DIFF
--- a/src/kcm/kcm_fcitx5.json
+++ b/src/kcm/kcm_fcitx5.json
@@ -13,7 +13,7 @@
         "Description[ru]": "Настроить метод ввода",
         "Description[zh_CN]": "配置输入法",
         "Description[zh_TW]": "設定輸入法",
-        "Icon": "fcitx",
+        "Icon": "preferences-desktop-keyboard",
         "Name": "Input Method",
         "Name[ca]": "Mètode d'entrada",
         "Name[da]": "Inputmetode",


### PR DESCRIPTION
The generic name "Input Method" is currently used in the KCM, and the `fcitx` icon is almost incomprehensible and breaks from the coloured icons that are used normally in Plasma System Settings. It just looks like a black and white Linux penguin at the size that it's rendered at. 

Using the default keyboard icon would be clearer, especially considering it's in Language and Time section. 