### PR TITLE
refactor: replace non-empty QString constructors with QStringLiteral()

### DIFF
--- a/layout/keyboardlayoutwidget.cpp
+++ b/layout/keyboardlayoutwidget.cpp
@@ -109,7 +109,7 @@ static QString FcitxXkbFindXkbRulesFile() {
     QString rulesName = FcitxXkbGetRulesName();
 
     if (!rulesName.isEmpty()) {
-        rulesFile = QString("%1/rules/%2.xml")
+        rulesFile = QStringLiteral("%1/rules/%2.xml")
                         .arg(XKEYBOARDCONFIG_XKBBASE)
                         .arg(rulesName);
     }

--- a/src/kcm/main.cpp
+++ b/src/kcm/main.cpp
@@ -183,7 +183,7 @@ void configOptionToVariant(QVariantList &options,
         for (const auto &subOption : subOptions) {
             auto map = subOption.value<QVariantMap>();
             if (map["isSection"].toBool()) {
-                map["description"] = QString("%1 > %2").arg(
+                map["description"] = QStringLiteral("%1 > %2").arg(
                     option.description(), map["description"].toString());
                 options.append(map);
             } else {
@@ -418,7 +418,7 @@ void FcitxModule::fixLayout() {
     const auto &imEntries = imConfig_->imEntries();
     if (imEntries.size() > 0 &&
         imEntries[0].key() !=
-            QString("keyboard-%0").arg(imConfig_->defaultLayout()) &&
+            QStringLiteral("keyboard-%0").arg(imConfig_->defaultLayout()) &&
         imEntries[0].key().startsWith("keyboard-")) {
         auto layoutString = imEntries[0].key().mid(9);
         imConfig_->setDefaultLayout(layoutString);
@@ -426,7 +426,7 @@ void FcitxModule::fixLayout() {
 }
 
 void FcitxModule::fixInputMethod() {
-    auto imname = QString("keyboard-%0").arg(imConfig_->defaultLayout());
+    auto imname = QStringLiteral("keyboard-%0").arg(imConfig_->defaultLayout());
     FcitxQtStringKeyValue imEntry;
     int i = 0;
     auto imEntries = imConfig_->imEntries();

--- a/src/lib/configlib/font.cpp
+++ b/src/lib/configlib/font.cpp
@@ -101,7 +101,7 @@ QString fcitx::kcm::fontToString(const QFont &font) {
         break;
     }
     style = styles.join(" ");
-    return QString("%1%2%3 %4")
+    return QStringLiteral("%1%2%3 %4")
         .arg(font.family(), (!style.isEmpty() ? " " : ""), style,
              QString::number(font.pointSize()));
 }

--- a/src/lib/configlib/layoutprovider.h
+++ b/src/lib/configlib/layoutprovider.h
@@ -58,7 +58,7 @@ public:
             if (variant.isEmpty()) {
                 return layout;
             }
-            return QString("%1-%2").arg(layout, variant);
+            return QStringLiteral("%1-%2").arg(layout, variant);
         }
         return QString();
     }

--- a/src/lib/configlib/model.cpp
+++ b/src/lib/configlib/model.cpp
@@ -405,7 +405,8 @@ QVariant FilteredIMModel::data(const QModelIndex &index, int role) const {
         return QString();
     }
     case FcitxIMActiveRole:
-        return index.row() > 0 ? QString("active") : QString("inactive");
+        return index.row() > 0 ? QStringLiteral("active")
+                               : QStringLiteral("inactive");
 
     default:
         return QVariant();

--- a/src/lib/configwidgetslib/addonselector.cpp
+++ b/src/lib/configwidgetslib/addonselector.cpp
@@ -275,8 +275,8 @@ void AddonDelegate::configureClicked() {
     }
     auto addonName = index.data(Qt::DisplayRole).toString();
     QPointer<QDialog> dialog = ConfigWidget::configDialog(
-        parent_, parent_->dbus(), QString("fcitx://config/addon/%1").arg(name),
-        addonName);
+        parent_, parent_->dbus(),
+        QStringLiteral("fcitx://config/addon/%1").arg(name), addonName);
     if (dialog) {
         dialog->exec();
         delete dialog;

--- a/src/lib/configwidgetslib/configwidget.cpp
+++ b/src/lib/configwidgetslib/configwidget.cpp
@@ -31,7 +31,7 @@ QString joinPath(const QString &path, const QString &option) {
     if (path.isEmpty()) {
         return option;
     }
-    return QString("%1/%2").arg(path, option);
+    return QStringLiteral("%1/%2").arg(path, option);
 }
 } // namespace
 

--- a/src/lib/configwidgetslib/impage.cpp
+++ b/src/lib/configwidgetslib/impage.cpp
@@ -283,10 +283,10 @@ void IMPage::selectDefaultLayout() {
         config_->setDefaultLayout(result.first);
     } else {
         config_->setDefaultLayout(
-            QString("%0-%1").arg(result.first, result.second));
+            QStringLiteral("%0-%1").arg(result.first, result.second));
     }
 
-    auto imname = QString("keyboard-%0").arg(config_->defaultLayout());
+    auto imname = QStringLiteral("keyboard-%0").arg(config_->defaultLayout());
     if (config_->imEntries().empty() ||
         config_->imEntries().front().key() != imname) {
         auto result = QMessageBox::question(
@@ -344,8 +344,8 @@ void IMPage::selectLayout() {
     if (result.second.isEmpty()) {
         config_->setLayout(imName, result.first);
     } else {
-        config_->setLayout(imName,
-                           QString("%0-%1").arg(result.first, result.second));
+        config_->setLayout(
+            imName, QStringLiteral("%0-%1").arg(result.first, result.second));
     }
 }
 
@@ -363,7 +363,7 @@ void IMPage::checkDefaultLayout() {
     const auto &imEntries = config_->imEntries();
     if (imEntries.size() > 0 &&
         imEntries[0].key() !=
-            QString("keyboard-%0").arg(config_->defaultLayout()) &&
+            QStringLiteral("keyboard-%0").arg(config_->defaultLayout()) &&
         imEntries[0].key().startsWith("keyboard-")) {
         // Remove "keyboard-".
         auto layoutString = imEntries[0].key().mid(9);
@@ -390,7 +390,8 @@ void IMPage::configureIM() {
     }
     const QString uniqueName = curIndex.data(FcitxIMUniqueNameRole).toString();
     QPointer<QDialog> dialog = ConfigWidget::configDialog(
-        this, dbus_, QString("fcitx://config/inputmethod/%1").arg(uniqueName),
+        this, dbus_,
+        QStringLiteral("fcitx://config/inputmethod/%1").arg(uniqueName),
         curIndex.data(Qt::DisplayRole).toString());
     if (dialog) {
         dialog->exec();

--- a/src/lib/configwidgetslib/listoptionwidget.cpp
+++ b/src/lib/configwidgetslib/listoptionwidget.cpp
@@ -46,7 +46,7 @@ public:
         int i = 0;
         values_.clear();
         while (true) {
-            auto value = readVariant(map, QString("%1%2%3")
+            auto value = readVariant(map, QStringLiteral("%1%2%3")
                                               .arg(path)
                                               .arg(path.isEmpty() ? "" : "/")
                                               .arg(i));
@@ -62,7 +62,7 @@ public:
     void writeValueTo(QVariantMap &map, const QString &path) {
         int i = 0;
         for (auto &value : values_) {
-            writeVariant(map, QString("%1/%2").arg(path).arg(i), value);
+            writeVariant(map, QStringLiteral("%1/%2").arg(path).arg(i), value);
             i++;
         }
         if (!i) {

--- a/src/lib/configwidgetslib/optionwidget.cpp
+++ b/src/lib/configwidgetslib/optionwidget.cpp
@@ -226,7 +226,8 @@ public:
         int i = 0;
         for (auto &key : keys) {
             auto value = QString::fromUtf8(key.toString().data());
-            writeVariant(map, QString("%1/%2").arg(path()).arg(i), value);
+            writeVariant(map, QStringLiteral("%1/%2").arg(path()).arg(i),
+                         value);
             i++;
         }
         if (keys.empty()) {
@@ -241,7 +242,7 @@ private:
         int i = 0;
         QList<Key> keys;
         while (true) {
-            auto value = readString(map, QString("%1%2%3")
+            auto value = readString(map, QStringLiteral("%1%2%3")
                                              .arg(path)
                                              .arg(path.isEmpty() ? "" : "/")
                                              .arg(i));
@@ -320,18 +321,18 @@ public:
 
         int i = 0;
         while (true) {
-            auto value =
-                readString(option.properties(), QString("Enum/%1").arg(i));
+            auto value = readString(option.properties(),
+                                    QStringLiteral("Enum/%1").arg(i));
             if (value.isNull()) {
                 break;
             }
-            auto text =
-                readString(option.properties(), QString("EnumI18n/%1").arg(i));
+            auto text = readString(option.properties(),
+                                   QStringLiteral("EnumI18n/%1").arg(i));
             if (text.isEmpty()) {
                 text = value;
             }
-            auto subConfigPath = readString(option.properties(),
-                                            QString("SubConfigPath/%1").arg(i));
+            auto subConfigPath = readString(
+                option.properties(), QStringLiteral("SubConfigPath/%1").arg(i));
             comboBox_->addItem(text, value);
             comboBox_->setItemData(i, subConfigPath, subConfigPathRole);
             i++;
@@ -578,8 +579,8 @@ bool OptionWidget::execOptionDialog(QWidget *parent,
     } else {
         QFormLayout *subLayout = new QFormLayout;
         dialogLayout->addLayout(subLayout);
-        optionWidget =
-            addWidget(subLayout, option, QString("Value"), dialog.data());
+        optionWidget = addWidget(subLayout, option, QStringLiteral("Value"),
+                                 dialog.data());
         if (!optionWidget) {
             return false;
         }
@@ -630,13 +631,13 @@ QString OptionWidget::prettify(const fcitx::FcitxQtConfigOption &option,
         QMap<QString, QString> enumMap;
         int i = 0;
         while (true) {
-            auto value =
-                readString(option.properties(), QString("Enum/%1").arg(i));
+            auto value = readString(option.properties(),
+                                    QStringLiteral("Enum/%1").arg(i));
             if (value.isNull()) {
                 break;
             }
-            auto text =
-                readString(option.properties(), QString("EnumI18n/%1").arg(i));
+            auto text = readString(option.properties(),
+                                   QStringLiteral("EnumI18n/%1").arg(i));
             if (text.isEmpty()) {
                 text = value;
             }


### PR DESCRIPTION
- Qt provides a macro `QStringLiteral()`, which makes constructing QString objects from string literals more efficient.