### PR TITLE
Just use translated language name and country code for language name from iso639 and iso3166

### DIFF
--- a/src/lib/configlib/CMakeLists.txt
+++ b/src/lib/configlib/CMakeLists.txt
@@ -16,5 +16,9 @@ set_target_properties(configlib PROPERTIES
     AUTOUIC_OPTIONS "-tr=fcitx::tr2fcitx;--include=fcitxqti18nhelper.h"
 )
 target_include_directories(configlib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(configlib Qt${QT_MAJOR_VERSION}::Core Qt${QT_MAJOR_VERSION}::Gui Fcitx5Qt${QT_MAJOR_VERSION}::DBusAddons Fcitx5::Core Fcitx5::Utils)
+target_link_libraries(configlib
+    Qt${QT_MAJOR_VERSION}::Core Qt${QT_MAJOR_VERSION}::Gui Fcitx5Qt${QT_MAJOR_VERSION}::DBusAddons
+    Fcitx5::Core Fcitx5::Utils
+    Fcitx5Qt${QT_MAJOR_VERSION}::WidgetsAddons KF${QT_MAJOR_VERSION}::I18n PkgConfig::XkbFile
+)
 

--- a/src/lib/configlib/iso639.cpp
+++ b/src/lib/configlib/iso639.cpp
@@ -37,14 +37,20 @@ QMap<QString, QString> readAlpha3ToNameMap(const char *name, const char *base) {
             continue;
         }
         auto alpha3 = item.toObject().value("alpha_3").toString();
+        auto alpha2 = item.toObject().value("alpha_2").toString();
         auto bibliographic = item.toObject().value("bibliographic").toString();
         auto name = item.toObject().value("name").toString();
-        if (alpha3.isEmpty() || name.isEmpty()) {
+        if (name.isEmpty()) {
             continue;
         }
-        map.insert(alpha3, name);
-        if (!bibliographic.isEmpty()) {
-            map.insert(bibliographic, name);
+        if (!alpha2.isEmpty()) {
+            map.insert(alpha2, name);
+        }
+        if (!alpha3.isEmpty()) {
+            map.insert(alpha3, name);
+            if (!bibliographic.isEmpty()) {
+                map.insert(bibliographic, name);
+            }
         }
     }
     return map;

--- a/src/lib/configlib/iso639.h
+++ b/src/lib/configlib/iso639.h
@@ -33,6 +33,22 @@ public:
         return value;
     }
 
+    QString queryNative(const QString &code) const {
+        auto value = iso639_2data_.value(code);
+        if (!value.isEmpty()) {
+            return value;
+        }
+        value = iso639_3data_.value(code);
+        if (!value.isEmpty()) {
+            return value;
+        }
+        value = iso639_5data_.value(code);
+        if (!value.isEmpty()) {
+            return value;
+        }
+        return value;
+    }
+
 private:
     QMap<QString, QString> iso639_2data_;
     QMap<QString, QString> iso639_3data_;

--- a/src/lib/configlib/model.h
+++ b/src/lib/configlib/model.h
@@ -6,12 +6,19 @@
 #ifndef _KCM_FCITX_MODEL_H_
 #define _KCM_FCITX_MODEL_H_
 
+#include "iso639.h"
+#include <QAbstractItemModel>
+#include <QHash>
+#include <QList>
+#include <QObject>
 #include <QSet>
 #include <QSortFilterProxyModel>
+#include <QVariant>
+#include <Qt>
 #include <fcitxqtdbustypes.h>
+#include <utility>
 
-namespace fcitx {
-namespace kcm {
+namespace fcitx::kcm {
 
 enum {
     FcitxRowTypeRole = 0x324da8fc,
@@ -31,6 +38,19 @@ public:
     virtual void
     filterIMEntryList(const FcitxQtInputMethodEntryList &imEntryList,
                       const FcitxQtStringKeyValueList &enabledIMs) = 0;
+
+protected:
+    struct LanguageNames {
+        // Language names in own locale
+        QString nativeName;
+        // Language names in system locale
+        QString localName;
+    };
+
+    const LanguageNames &languageNames(const QString &langCode) const;
+
+    mutable QHash<QString, LanguageNames> languageNames_;
+    Iso639 iso639_;
 };
 
 class CategorizedItemModel : public QAbstractItemModel {
@@ -60,7 +80,7 @@ public:
     AvailIMModel(QObject *parent = 0);
     void
     filterIMEntryList(const FcitxQtInputMethodEntryList &imEntryList,
-                      const FcitxQtStringKeyValueList &enabledIMs) override;
+                      const FcitxQtStringKeyValueList &enabledIMList) override;
 
 protected:
     int listSize() const override { return filteredIMEntryList.size(); }
@@ -95,7 +115,7 @@ public:
     const QString &filterText() const { return filterText_; }
     void setFilterText(const QString &text);
     bool showOnlyCurrentLanguage() const { return showOnlyCurrentLanguage_; }
-    void setShowOnlyCurrentLanguage(bool checked);
+    void setShowOnlyCurrentLanguage(bool show);
 
     void
     filterIMEntryList(const FcitxQtInputMethodEntryList &imEntryList,
@@ -153,8 +173,6 @@ private:
     FcitxQtStringKeyValueList enabledIMList_;
 };
 
-} // namespace kcm
-
-} // namespace fcitx
+} // namespace fcitx::kcm
 
 #endif // _KCM_FCITX_MODEL_H_


### PR DESCRIPTION
QLocale, or icu locale, no matter which, has only iso639-2 support. We
may use code from iso639-3 or even more.

Also, the native language, since we only use them for terriority, which
means in real only zh_CN & zh_TW will be using such function. It doesn't
really serve the purpose of always show language name in native
language.

In the end, the change is:
1. use iso639 to get langauge name, in English & Translated
2. Display with translated, but search with both English / Translated.

Fix #92
