### PR TITLE
fix:check for empty URI string

### DIFF
--- a/src/lib/configlib/addonmodel.cpp
+++ b/src/lib/configlib/addonmodel.cpp
@@ -373,6 +373,9 @@ void AddonProxyModel::setFilterText(const QString &text) {
 }
 
 void launchExternalConfig(const QString &uri, WId wid) {
+    if (uri.isEmpty()) {
+        return;
+    }
     QFileInfo pathToWrapper(FCITX5_QT_GUI_WRAPPER);
     QDir dirToWrapper = pathToWrapper.dir();
     if (uri.startsWith("fcitx://config/addon/")) {


### PR DESCRIPTION
三方输入法可能存在外部配置但uri为空的情情况,这时点击配置会触发qt判空断言,导致工具崩溃

<img width="788" height="41" alt="image" src="https://github.com/user-attachments/assets/5b1440b5-2da8-4ba2-ab9a-cdf0eea70c0b" />
