### PR TITLE
configlib: Do not link to unused PkgConfig::XkbFile

### DIFF
--- a/src/lib/configlib/CMakeLists.txt
+++ b/src/lib/configlib/CMakeLists.txt
@@ -19,6 +19,6 @@ target_include_directories(configlib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR} ${CMA
 target_link_libraries(configlib
     Qt${QT_MAJOR_VERSION}::Core Qt${QT_MAJOR_VERSION}::Gui Fcitx5Qt${QT_MAJOR_VERSION}::DBusAddons
     Fcitx5::Core Fcitx5::Utils
-    Fcitx5Qt${QT_MAJOR_VERSION}::WidgetsAddons PkgConfig::XkbFile
+    Fcitx5Qt${QT_MAJOR_VERSION}::WidgetsAddons
 )
 


### PR DESCRIPTION
No XKB headers are included for configlib, and no Xkb* symbols are unused in this submodule. Linking to the library seems unnecessary here.