### PR TITLE
fix: emit valueChanged signals for List and Optional widgets

### DIFF
--- a/src/lib/configwidgetslib/listoptionwidget.cpp
+++ b/src/lib/configwidgetslib/listoptionwidget.cpp
@@ -151,6 +151,14 @@ ListOptionWidget::ListOptionWidget(const FcitxQtConfigOption &option,
 
     connect(model_, &QAbstractListModel::rowsMoved, this,
             [this]() { updateButton(); });
+    connect(model_, &QAbstractListModel::rowsInserted, this,
+            &OptionWidget::valueChanged);
+    connect(model_, &QAbstractListModel::rowsRemoved, this,
+            &OptionWidget::valueChanged);
+    connect(model_, &QAbstractListModel::dataChanged, this,
+            &OptionWidget::valueChanged);
+    connect(model_, &QAbstractListModel::rowsMoved, this,
+            &OptionWidget::valueChanged);
     connect(addButton, &QAbstractButton::clicked, this, [this]() {
         QVariant result;
         auto ok = OptionWidget::execOptionDialog(this, subOption_, result);

--- a/src/lib/configwidgetslib/optionaloptionwidget.cpp
+++ b/src/lib/configwidgetslib/optionaloptionwidget.cpp
@@ -48,8 +48,14 @@ OptionalOptionWidget::OptionalOptionWidget(const FcitxQtConfigOption &option,
     valueCheckBox_ = new QCheckBox;
     connect(valueCheckBox_, &QCheckBox::checkStateChanged, this,
             &OptionalOptionWidget::updateValueWidget);
+    connect(valueCheckBox_, &QCheckBox::checkStateChanged, this,
+            &OptionWidget::valueChanged);
     subWidget_ = OptionWidget::addWidget(layout, subOption_, "Value", this,
                                          valueCheckBox_);
+    if (subWidget_) {
+        connect(subWidget_, &OptionWidget::valueChanged, this,
+                &OptionWidget::valueChanged);
+    }
     subWidget_->setSkipConfig(true);
     setLayout(layout);
 


### PR DESCRIPTION
# Description
This PR addresses issue #100 by ensuring that `ListOptionWidget` and `OptionalOptionWidget` correctly notify the parent configuration dialog when their values change.

Previously, these widgets modified their internal state/model but failed to emit the `OptionWidget::valueChanged()` signal. This caused the "Apply" and "OK" buttons in the main configuration window to remain disabled, effectively preventing users from saving changes to these fields unless another unrelated setting was also modified.

## Changes
- **ListOptionWidget**: Connected `rowsInserted`, `rowsRemoved`, `dataChanged`, and `rowsMoved` signals from the internal model to `valueChanged()`.
- **OptionalOptionWidget**: Connected the checkbox state change and sub-widget's `valueChanged` signal to the parent's `valueChanged()`.

## Evidence
In `src/lib/configwidgetslib/optionwidget.cpp`, all other basic widgets (Integer, String, Boolean, Enum) already follow this pattern to enable change detection:

```cpp
// Example from StringOptionWidget
connect(lineEdit_, &QLineEdit::textChanged, this, &OptionWidget::valueChanged);
```

This PR brings `ListOptionWidget` and `OptionalOptionWidget` into consistency with the rest of the library.

Fixes #100