### PR TITLE
kcm_fcitx5.json: add a bugreport URL

### DIFF
--- a/src/kcm/kcm_fcitx5.json
+++ b/src/kcm/kcm_fcitx5.json
@@ -1,6 +1,7 @@
 {
     "Categories": "Qt;KDE;X-KDE-settings-fcitx;",
     "KPlugin": {
+        "BugReportUrl": "https://github.com/fcitx/fcitx5-configtool/issues",
         "Description": "Configure Input Method",
         "Description[ca]": "Configura el mètode d'entrada",
         "Description[da]": "Konfigurer inputmetode",

--- a/src/kcm/kcm_fcitx5.json
+++ b/src/kcm/kcm_fcitx5.json
@@ -1,7 +1,7 @@
 {
     "Categories": "Qt;KDE;X-KDE-settings-fcitx;",
     "KPlugin": {
-        "BugReportUrl": "https://github.com/fcitx/fcitx5-configtool/issues?dummy=1",
+        "BugReportUrl": "https://github.com/fcitx/fcitx5/issues?dummy=1",
         "Description": "Configure Input Method",
         "Description[ca]": "Configura el mètode d'entrada",
         "Description[da]": "Konfigurer inputmetode",

--- a/src/kcm/kcm_fcitx5.json
+++ b/src/kcm/kcm_fcitx5.json
@@ -1,7 +1,7 @@
 {
     "Categories": "Qt;KDE;X-KDE-settings-fcitx;",
     "KPlugin": {
-        "BugReportUrl": "https://github.com/fcitx/fcitx5-configtool/issues",
+        "BugReportUrl": "https://github.com/fcitx/fcitx5-configtool/issues?dummy=1",
         "Description": "Configure Input Method",
         "Description[ca]": "Configura el mètode d'entrada",
         "Description[da]": "Konfigurer inputmetode",


### PR DESCRIPTION
This will show up here and it will allow directing users directly to the correct issue tracker
<img width="314" height="226" alt="image" src="https://github.com/user-attachments/assets/0375ba66-ba0e-4c7b-844a-766e8d6d8aad" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a bug report URL in the configuration metadata to make it easier to submit and track issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->